### PR TITLE
set the readable and writable properties to true

### DIFF
--- a/lib/pty.js
+++ b/lib/pty.js
@@ -87,6 +87,7 @@ var Terminal = function(file, args, opt) {
   this.name = name;
   this.cols = cols;
   this.rows = rows;
+  this.readable = this.writable = true;
 
   Terminal.total++;
   this.socket.on('close', function() {


### PR DESCRIPTION
I was having problems `.pipe()`-ing to a `Terminal` instance (from `process.stdin`).

Setting the `readable` and `writable` properties fixes it.

Cheers!
