### PR TITLE
Fix "Error: Symbol pty_module not found"

### DIFF
--- a/src/pty.cc
+++ b/src/pty.cc
@@ -538,3 +538,5 @@ init(Handle<Object> target) {
   NODE_SET_METHOD(target, "resize", PtyResize);
   NODE_SET_METHOD(target, "process", PtyGetProc);
 }
+
+NODE_MODULE(pty, init)


### PR DESCRIPTION
This fixes the "Error: Symbol pty_module not found." error (Issue #20) which was happening in node v0.9.x. The init function in pty.cc is now exported with the NODE_MODULE macro.
