### PR TITLE
Add uid and gid options for user impersonation

### DIFF
--- a/lib/pty.js
+++ b/lib/pty.js
@@ -59,7 +59,11 @@ function Terminal(file, args, opt) {
   env = environ(env);
 
   // fork
-  term = pty.fork(file, args, env, cwd, cols, rows);
+  if (opt.uid && opt.gid) {
+    term = pty.fork(file, args, env, cwd, cols, rows, opt.uid, opt.gid);
+  } else {
+    term = pty.fork(file, args, env, cwd, cols, rows);
+  }
   this.socket = new net.Socket(term.fd);
   this.socket.setEncoding('utf8');
   this.socket.resume();

--- a/src/pty.cc
+++ b/src/pty.cc
@@ -105,7 +105,9 @@ static Handle<Value>
 PtyFork(const Arguments& args) {
   HandleScope scope;
 
-  if (args.Length() != 6
+  if ((args.Length() != 6
+        && (args.Length() != 8 || !args[6]->IsNumber() || !args[7]->IsNumber())
+      )
       || !args[0]->IsString()
       || !args[1]->IsArray()
       || !args[2]->IsArray()
@@ -113,7 +115,7 @@ PtyFork(const Arguments& args) {
       || !args[4]->IsNumber()
       || !args[5]->IsNumber()) {
     return ThrowException(Exception::Error(
-      String::New("Usage: pty.fork(file, args, env, cwd, cols, rows)")));
+      String::New("Usage: pty.fork(file, args, env, cwd, cols, rows[, uid, gid])")));
   }
 
   // node/src/node_child_process.cc
@@ -156,6 +158,13 @@ PtyFork(const Arguments& args) {
   winp.ws_xpixel = 0;
   winp.ws_ypixel = 0;
 
+  int uid = -1;
+  int gid = -1;
+  if (args.Length() == 8) {
+    uid = args[6]->IntegerValue();
+    gid = args[7]->IntegerValue();
+  }
+
   // fork the pty
   int master = -1;
   char name[40];
@@ -175,6 +184,17 @@ PtyFork(const Arguments& args) {
         String::New("forkpty(3) failed.")));
     case 0:
       if (strlen(cwd)) chdir(cwd);
+
+      if (uid != -1 && gid != -1) {
+        if (setgid(gid) == -1) {
+          perror("setgid(2) failed.");
+          _exit(1);
+        }
+        if (setuid(uid) == -1) {
+          perror("setuid(2) failed.");
+          _exit(1);
+        }
+      }
 
       pty_execvpe(argv[0], argv, env);
 

--- a/test/children/uidgid.js
+++ b/test/children/uidgid.js
@@ -1,0 +1,4 @@
+var assert = require('assert');
+
+assert.equal(process.getuid(), 777);
+assert.equal(process.getgid(), 777);

--- a/test/index.js
+++ b/test/index.js
@@ -24,11 +24,20 @@ var tests = [
     test: function () {
       this.resize(100, 100);
     }
+  }, {
+    name: 'should change uid/gid',
+    command: [ 'children/uidgid.js' ],
+    options: { cwd: __dirname, uid: 777, gid: 777 },
+    test: function () {}
   }
 ];
 
 describe('Pty', function() {
   tests.forEach(function (testCase) {
+    if (testCase.options.uid && testCase.options.gid && process.getgid() !== 0) {
+      // Skip tests that contains user impersonation if we are not able to do so.
+      return it.skip(testCase.name);
+    }
     it(testCase.name, function (done) {
       var term = pty.fork(process.execPath, testCase.command, testCase.options);
       term.pipe(process.stderr);


### PR DESCRIPTION
Hello again @chjj,

Here's another pull request allowing to run the pty as another user. It fixes @filirom1's #23.
The added test is disabled when not root, I haven't spent too much time looking for a way to sudo this test.

Is anyone familiar with node addons aware of better ways to provide parameters ? I found it not so natural to add those 2 optional parameters.
