### PR TITLE
BSD support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,7 +18,9 @@
           'src/unix/pty.cc'
         ],
         'libraries': [
-          '-lutil'
+          '-lutil',
+          '-L/usr/lib',
+          '-L/usr/local/lib'
         ],
       }],
       # http://www.gnu.org/software/gnulib/manual/html_node/forkpty.html


### PR DESCRIPTION
Add /usr/local/lib to gyp link path - makes this build on OpenBSD 5.3.
