### PR TITLE
Issue #75: Fix 'unsupported fd type: TTY' error in pty.open()

### DIFF
--- a/lib/pty.js
+++ b/lib/pty.js
@@ -166,11 +166,11 @@ Terminal.open = function(opt) {
   // open
   term = pty.open(cols, rows);
 
-  self.master = new net.Socket(term.master);
+  self.master = new tty.ReadStream(term.master);
   self.master.setEncoding('utf8');
   self.master.resume();
 
-  self.slave = new net.Socket(term.slave);
+  self.slave = new tty.ReadStream(term.slave);
   self.slave.setEncoding('utf8');
   self.slave.resume();
 


### PR DESCRIPTION
Applying the fix described in issue #32 for a similar issue, which
replaces "new net.Socket()" with "new tty.ReadStream()"

Signed-off-by: Dan O'Donovan dan@emutex.com
