### PR TITLE
Look for system util.h in Node 0.10.29

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -30,10 +30,10 @@
 #include <pty.h>
 #elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__)
 /**
- * From node v0.11.0 there is also a "util.h" in node/src, which would confuse
+ * From node v0.10.29 there is also a "util.h" in node/src, which would confuse
  * the compiler when looking for "util.h".
  */
-#if NODE_VERSION_AT_LEAST(0, 11, 0)
+#if NODE_VERSION_AT_LEAST(0, 10, 29)
 #include </usr/include/util.h>
 #else
 #include <util.h>


### PR DESCRIPTION
It seems that a local util.h now exists in the 0.10.x branch of Node.js as well (currently only in 0.10.29).
