### PR TITLE
util.h is also part of 10.29

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -33,7 +33,7 @@
  * From node v0.11.0 there is also a "util.h" in node/src, which would confuse
  * the compiler when looking for "util.h".
  */
-#if NODE_VERSION_AT_LEAST(0, 11, 0)
+#if NODE_VERSION_AT_LEAST(0, 10, 29)
 #include </usr/include/util.h>
 #else
 #include <util.h>


### PR DESCRIPTION
Installation fails for node 10.29 and/or jxcore b2.1.9+ since they also have util.h
