### PR TITLE
Fix issue on kill, process have to consume child output stream or have t...

### DIFF
--- a/lib/pty.js
+++ b/lib/pty.js
@@ -8,6 +8,7 @@ var net = require('net');
 var tty = require('tty');
 var extend = require('extend');
 var pty = require('../build/Release/pty.node');
+var waitpid = require("waitpid");
 
 /**
  * Terminal
@@ -322,6 +323,7 @@ Terminal.prototype.destroy = function() {
 Terminal.prototype.kill = function(sig) {
   try {
     process.kill(this.pid, sig || 'SIGHUP');
+    waitpid(this.pid);
   } catch(e) {
     ;
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pty.js",
   "description": "Pseudo terminals for node.",
   "author": "Christopher Jeffrey",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "./index.js",
   "repository": "git://github.com/chjj/pty.js.git",
   "homepage": "https://github.com/chjj/pty.js",
@@ -24,7 +24,8 @@
   ],
   "dependencies": {
     "extend": "~1.2.1",
-    "nan": "~1.0.0"
+    "nan": "~1.0.0",
+    "waitpid":  "~0.1.1"
   },
   "devDependencies": {
     "mocha": "~1.16.2"


### PR DESCRIPTION
Fix issue on kill, process have to consume child output stream or have to waitpid.

If we don't waitpid spawning a new tty session and then kill it will create a bash zombie process.

```
root 1795 0.2 9.6 104212 48500 ? Sl 01:00 1:39 node /opt/controller-app/lib/index.js
root 2914 0.1 0.0 0 0 ? Zs 13:22 0:00 _ [bash] <defunct>
root 3137 0.2 0.0 0 0 ? Zs 13:24 0:00 _ [bash] <defunct> 
```
