### PR TITLE
Fixed install warning

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -182,8 +182,9 @@ NAN_METHOD(PtyFork) {
     case -1:
       return NanThrowError("forkpty(3) failed.");
     case 0:
-      if (strlen(cwd)) chdir(cwd);
-
+      if (strlen(cwd) && chdir(cwd))
+        perror("chdir failed");
+      
       if (uid != -1 && gid != -1) {
         if (setgid(gid) == -1) {
           perror("setgid(2) failed.");


### PR DESCRIPTION
``` cpp
./src/unix/pty.cc: In function ‘v8::Handle<v8::Value> PtyFork(const v8::Arguments&)’:
../src/unix/pty.cc:185:34: warning: ignoring return value of ‘int chdir(const char*)’, declared with attribute warn_unused_result [-Wunused-result]
       if (strlen(cwd)) chdir(cwd);
```
