### PR TITLE
Switch to new Streams API.

### DIFF
--- a/lib/pty.js
+++ b/lib/pty.js
@@ -8,6 +8,8 @@ var net = require('net');
 var tty = require('tty');
 var extend = require('extend');
 var pty = require('../build/Release/pty.node');
+var stream = require('stream');
+var util = require('util');
 
 /**
  * Terminal
@@ -23,9 +25,11 @@ var pty = require('../build/Release/pty.node');
 //  });
 
 function Terminal(file, args, opt) {
+  stream.Duplex.call(this, opt);
   if (!(this instanceof Terminal)) {
     return new Terminal(file, args, opt);
   }
+
 
   var self = this
     , env
@@ -99,7 +103,7 @@ function Terminal(file, args, opt) {
   // setup
   this.socket.on('error', function(err) {
     // close
-    self._close();
+    self.close();
 
     // EIO, happens when someone closes our child
     // process: the only process in the terminal.
@@ -131,12 +135,14 @@ function Terminal(file, args, opt) {
   Terminal.total++;
   this.socket.on('close', function() {
     Terminal.total--;
-    self._close();
+    self.close();
     self.emit('exit', null);
   });
 
   env = null;
 }
+util.inherits(Terminal, stream.Duplex);
+
 
 Terminal.fork =
 Terminal.spawn =
@@ -178,6 +184,7 @@ Terminal.open = function(opt) {
   self.pid = null;
   self.fd = term.master;
   self.pty = term.pty;
+  self.canPush = false;
 
   self.file = process.argv[0] || 'node';
   self.name = process.env.TERM || '';
@@ -197,7 +204,12 @@ Terminal.open = function(opt) {
   Terminal.total++;
   self.socket.on('close', function() {
     Terminal.total--;
-    self._close();
+    self.close();
+  });
+
+  self.socket.on('readable', function() {
+    if(self._canPush)
+      self._canPush = self.push(self.socket.read());
   });
 
   return self;
@@ -216,66 +228,13 @@ Terminal.total = 0;
  * Events
  */
 
-// Don't inherit from net.Socket in
-// order to avoid collisions.
+Terminal.prototype._read = function() {
+  this._canPush = this.push(this.socket.read());
+}
 
-Terminal.prototype.write = function(data) {
-  return this.socket.write(data);
-};
-
-Terminal.prototype.end = function(data) {
-  return this.socket.end(data);
-};
-
-Terminal.prototype.pipe = function(dest, options) {
-  return this.socket.pipe(dest, options);
-};
-
-Terminal.prototype.pause = function() {
-  this.socket.pause();
-};
-
-Terminal.prototype.resume = function() {
-  this.socket.resume();
-};
-
-Terminal.prototype.setEncoding = function(enc) {
-  if (this.socket._decoder) {
-    delete this.socket._decoder;
-  }
-  if (enc) {
-    this.socket.setEncoding(enc);
-  }
-};
-
-Terminal.prototype.addListener =
-Terminal.prototype.on = function(type, func) {
-  this.socket.on(type, func);
-  return this;
-};
-
-Terminal.prototype.emit = function() {
-  return this.socket.emit.apply(this.socket, arguments);
-};
-
-Terminal.prototype.listeners = function(type) {
-  return this.socket.listeners(type);
-};
-
-Terminal.prototype.removeListener = function(type, func) {
-  this.socket.removeListener(type, func);
-  return this;
-};
-
-Terminal.prototype.removeAllListeners = function(type) {
-  this.socket.removeAllListeners(type);
-  return this;
-};
-
-Terminal.prototype.once = function(type, func) {
-  this.socket.once(type, func);
-  return this;
-};
+Terminal.prototype._write = function(chunk, encoding, callback) {
+  this.socket.write(chunk, encoding, callback);
+}
 
 Terminal.prototype.__defineGetter__('stdin', function() {
   return this;
@@ -342,18 +301,11 @@ Terminal.prototype.redraw = function() {
   }, 30);
 };
 
+Terminal.prototype.close = Terminal.prototype.end;
+
 Terminal.prototype.__defineGetter__('process', function() {
   return pty.process(this.fd, this.pty) || this.file;
 });
-
-Terminal.prototype._close = function() {
-  this.socket.writable = false;
-  this.socket.readable = false;
-  this.write = function() {};
-  this.end = function() {};
-  this.writable = false;
-  this.readable = false;
-};
 
 /**
  * Helpers

--- a/lib/pty.js
+++ b/lib/pty.js
@@ -25,7 +25,7 @@ var util = require('util');
 //  });
 
 function Terminal(file, args, opt) {
-  stream.Duplex.call(this, opt);
+  Terminal.super_.call(this, opt);
   if (!(this instanceof Terminal)) {
     return new Terminal(file, args, opt);
   }

--- a/lib/pty_win.js
+++ b/lib/pty_win.js
@@ -157,12 +157,12 @@ function Terminal(file, args, opt) {
     self.dataPipe = socket;
 
     // These events needs to be forwarded.
-    ['connect', 'data', 'end', 'timeout', 'drain'].forEach(function(event) {
-      self.dataPipe.on(event, function(data) {
+    ['connect', 'readable', 'end', 'timeout', 'drain'].forEach(function(event) {
+      self.dataPipe.on(event, function() {
 
         // Wait until the first data event is fired
         // then we can run deferreds.
-        if(!self.isReady && event == 'data') {
+        if(!self.isReady && event == 'readable') {
 
           // Terminal is now ready and we can
           // avoid having to defer method calls.
@@ -184,7 +184,7 @@ function Terminal(file, args, opt) {
         }
 
         // Emit to dummy socket
-        self.socket.emit(event, data);
+        self.socket.emit.apply(self.socket, arguments);
 
       });
     });
@@ -263,9 +263,9 @@ Terminal.open = function () {
  * Events
  */
 
-Terminal.prototype.write = function(data) {
+Terminal.prototype._write = function(chunk, encoding, callback) {
   defer(this, function() {
-    this.dataPipe.write(data);
+    this.dataPipe.write(chunk, encoding, callback);
   });
 };
 


### PR DESCRIPTION
The following changes were made:

* Let Terminal implement stream.Duplex.

* Instead of shimming the this.socket, the API forwards the read/write commands to the socket.
  This has the benefit that the pipe event of a foreign writer will get Terminal instance
  instead of the socket instance.

This also includes changes at the windows side, but I'm not sure if they'll work as I don't have a windows system to test.