### PR TITLE
Bump version to make atom-term2 work

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "nan": "~1.0.0"
   },
   "devDependencies": {
-    "mocha": "~1.16.2"
+    "mocha": "~1.17.1"
   }
 }


### PR DESCRIPTION
Hi, would it be possible to bump the mocha dependency version to 1.17 so it will work with atom 0.169.0?

The issue was originated in webBoxio/atom-term2#83

Regards,
Carlos.