### PR TITLE
Add support for .on('exit', ...) returning process exit status

### DIFF
--- a/lib/pty.js
+++ b/lib/pty.js
@@ -268,8 +268,8 @@ Terminal.prototype.on = function(type, func) {
   return this;
 };
 
-Terminal.prototype.emit = function() {
-  if (arguments[0] === 'close') {
+Terminal.prototype.emit = function(evt) {
+  if (evt === 'close') {
     return this._internalee.emit.apply(this._internalee, arguments);
   }
 

--- a/lib/pty.js
+++ b/lib/pty.js
@@ -7,6 +7,7 @@
 var net = require('net');
 var tty = require('tty');
 var extend = require('extend');
+var EventEmitter = require('events').EventEmitter;
 var pty = require('../build/Release/pty.node');
 
 /**
@@ -45,6 +46,9 @@ function Terminal(file, args, opt) {
     };
     args = [];
   }
+
+  // for 'close'
+  this._internalee = new EventEmitter();
 
   // arguments
   args = args || [];
@@ -87,10 +91,14 @@ function Terminal(file, args, opt) {
 
   env = environ(env);
 
+  function afterExit(code, signal) {
+    self.emit('exit', code, signal);
+  }
+
   // fork
   term = opt.uid && opt.gid
-    ? pty.fork(file, args, env, cwd, cols, rows, opt.uid, opt.gid)
-    : pty.fork(file, args, env, cwd, cols, rows);
+    ? pty.fork(file, args, env, cwd, cols, rows, opt.uid, opt.gid, afterExit)
+    : pty.fork(file, args, env, cwd, cols, rows, afterExit);
 
   this.socket = new tty.ReadStream(term.fd);
   this.socket.setEncoding('utf8');
@@ -132,7 +140,7 @@ function Terminal(file, args, opt) {
   this.socket.on('close', function() {
     Terminal.total--;
     self._close();
-    self.emit('exit', null);
+    self.emit('close', null);
   });
 
   env = null;
@@ -250,11 +258,21 @@ Terminal.prototype.setEncoding = function(enc) {
 
 Terminal.prototype.addListener =
 Terminal.prototype.on = function(type, func) {
+
+  if (type === 'close') {
+      this._internalee.on('close', func);
+      return this;
+  }
+
   this.socket.on(type, func);
   return this;
 };
 
 Terminal.prototype.emit = function() {
+  if (arguments[0] === 'close') {
+    return this._internalee.emit.apply(this._internalee, arguments);
+  }
+
   return this.socket.emit.apply(this.socket, arguments);
 };
 


### PR DESCRIPTION
This should resolve #28 and adds the ability to get the exit code and signal (if killed by signal) when a pty spawned process exits.