### PR TITLE
Optional resuming of the socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ Makefile.gyp
 *.filters
 *.user
 *.project
+.idea
 test.js

--- a/lib/pty.js
+++ b/lib/pty.js
@@ -123,7 +123,10 @@ function Terminal(file, args, opt) {
 
   this.socket = TTYStream(term.fd);
   this.socket.setEncoding('utf8');
-  this.socket.resume();
+
+  if (opt.resume !== false) {
+    this.socket.resume();
+  }
 
   // setup
   this.socket.on('error', function(err) {

--- a/test/index.js
+++ b/test/index.js
@@ -61,4 +61,14 @@ describe('Pty', function() {
       setTimeout(testCase.test.bind(term), 1000);
     });
   });
+
+  it('should support starting with a paused socket', function (done) {
+    var term = pty.spawn('echo', ['Immediate output'], { resume: false });
+    setTimeout(function () {
+      term.stdout.on('data', function (chunk) {
+        assert.equal(chunk.trim(), 'Immediate output');
+        done();
+      });
+    }, 1);
+  });
 });


### PR DESCRIPTION
The immediate resumption the a socket means that output can be lost unless you start consuming it right away. In some cases, this behavior is undesirable. Adding an option to not automatically resume the socket enables data to be read after a delay.
