### PR TITLE
Fixes #137: Follow Windows conventions when composing cmdline

### DIFF
--- a/lib/pty_win.js
+++ b/lib/pty_win.js
@@ -48,11 +48,15 @@ function Agent(file, args, env, cwd, cols, rows, debug) {
 
     // Sanitize input variable.
     file = file;
-    args = args.join(' ');
     cwd = path.resolve(cwd);
 
+    // Compose command line
+    var cmdline = [file];
+    Array.prototype.push.apply(cmdline, args);
+    cmdline = argvToCommandLine(cmdline);
+
     // Start terminal session.
-    pty.startProcess(self.pid, file, args, env, cwd);
+    pty.startProcess(self.pid, file, cmdline, env, cwd);
 
     // Emit ready event.
     self.ptySocket.emit('ready_datapipe', socket);
@@ -345,6 +349,48 @@ function environ(env) {
   return pairs;
 }
 
+// Convert argc/argv into a Win32 command-line following the escaping convention
+// documented on MSDN.  (e.g. see CommandLineToArgvW documentation)
+// Copied from winpty project.
+function argvToCommandLine(argv) {
+  var result = '';
+  for (var argIndex = 0; argIndex < argv.length; argIndex++) {
+    if (argIndex > 0) {
+      result += ' ';
+    }
+    var arg = argv[argIndex];
+    var quote =
+      arg.indexOf(' ') != -1 ||
+      arg.indexOf('\t') != -1 ||
+      arg == '';
+    if (quote) {
+      result += '\"';
+    }
+    var bsCount = 0;
+    for (var i = 0; i < arg.length; i++) {
+      var p = arg[i];
+      if (p == '\\') {
+        bsCount++;
+      } else if (p == '"') {
+        result += '\\'.repeat(bsCount * 2 + 1);
+        result += '"';
+        bsCount = 0;
+      } else {
+        result += '\\'.repeat(bsCount);
+        bsCount = 0;
+        result += p;
+      }
+    }
+    if (quote) {
+      result += '\\'.repeat(bsCount * 2);
+      result += '\"';
+    } else {
+      result += '\\'.repeat(bsCount);
+    }
+  }
+  return result;
+}
+
 /**
  * Expose
  */
@@ -352,3 +398,7 @@ function environ(env) {
 module.exports = exports = Terminal;
 exports.Terminal = Terminal;
 exports.native = pty;
+
+if (process.env.NODE_ENV == 'test') {
+  exports.argvToCommandLine = argvToCommandLine;
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "terminal"
   ],
   "scripts": {
-    "test": "NODE_ENV=test mocha -R spec"
+    "test": "NODE_ENV=test mocha -R spec",
+    "test-windows": "set \"NODE_ENV=test\" && mocha -R spec test-windows"
   },
   "tags": [
     "pty",

--- a/test-windows/argvToCommandLine.js
+++ b/test-windows/argvToCommandLine.js
@@ -1,0 +1,59 @@
+var argvToCommandLine = require('../').argvToCommandLine
+var assert = require("assert");
+
+function check(input, expected) {
+  assert.equal(argvToCommandLine(input), expected);
+}
+
+describe("argvToCommandLine", function() {
+  describe("Plain strings", function() {
+    it("doesn't quote plain string", function() {
+      check(['asdf'], 'asdf');
+    });
+    it("doesn't escape backslashes", function() {
+      check(['\\asdf\\qwer\\'], '\\asdf\\qwer\\');
+    });
+    it("doesn't escape multiple backslashes", function() {
+      check(['asdf\\\\qwer'], 'asdf\\\\qwer');
+    });
+    it("adds backslashes before quotes", function() {
+      check(['"asdf"qwer"'], '\\"asdf\\"qwer\\"');
+    });
+    it("escapes backslashes before quotes", function() {
+      check(['asdf\\"qwer'], 'asdf\\\\\\"qwer');
+    });
+  });
+
+  describe("Quoted strings", function() {
+    it("quotes string with spaces", function() {
+      check(['asdf qwer'], '"asdf qwer"');
+    });
+    it("quotes empty string", function() {
+      check([''], '""');
+    });
+    it("quotes string with tabs", function() {
+      check(['asdf\tqwer'], '"asdf\tqwer"');
+    });
+    it("escapes only the last backslash", function() {
+      check(['\\asdf \\qwer\\'], '"\\asdf \\qwer\\\\"');
+    });
+    it("doesn't escape multiple backslashes", function() {
+      check(['asdf \\\\qwer'], '"asdf \\\\qwer"');
+    });
+    it("adds backslashes before quotes", function() {
+      check(['"asdf "qwer"'], '"\\"asdf \\"qwer\\""');
+    });
+    it("escapes backslashes before quotes", function() {
+      check(['asdf \\"qwer'], '"asdf \\\\\\"qwer"');
+    });
+    it("escapes multiple backslashes at the end", function() {
+      check(['asdf qwer\\\\'], '"asdf qwer\\\\\\\\"');
+    });
+  });
+
+  describe("Multiple arguments", function() {
+    it("joins arguments with spaces", function() {
+      check(['asdf', 'qwer zxcv', '', '"'], 'asdf "qwer zxcv" "" \\"');
+    });
+  });
+});


### PR DESCRIPTION
1. All parts of the command line are being escaped following the [convention documented on MSDN].(https://msdn.microsoft.com/en-us/library/windows/desktop/bb776391(v=vs.85).aspx)
2. The application is added as the first argument to follow the Windows convention:

> Because argv[0] is the module name, C programmers generally repeat the module name as the first token in the command line.
> [MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425%28v=vs.85%29.aspx)
> 
> (...) if you are launching other programs and passing an explicit lpApplicationName, then it behooves you to format the command line in a compatible manner. Otherwise, the results may not be what you expect.
> [The Old New Thing](https://blogs.msdn.microsoft.com/oldnewthing/20060515-07/?p=31203)
