### PR TITLE
added node-gyp to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   ],
   "dependencies": {
     "extend": "~1.2.1",
-    "nan": "2.3.5"
+    "nan": "2.3.5",
+    "node-gyp": "^3.4.0"
   },
   "devDependencies": {
     "mocha": "~1.17.1"


### PR DESCRIPTION
installing pty.js (or any package that depends on pty.js such as tty.js) fails with yarn. This happens because node-gyp (which is used in the Makefile) is not listed as a direct dependency.

Fix: I have added node-gyp to the dependencies in package.json.