### PR TITLE
Add prependListener method to fix piping in newer versions of Node

### DIFF
--- a/lib/pty.js
+++ b/lib/pty.js
@@ -292,6 +292,15 @@ Terminal.prototype.setEncoding = function(enc) {
   }
 };
 
+Terminal.prototype.prependListener = function(type, func) {
+  if (type === 'close') {
+    this._internalee.prependListener('close', func);
+    return this;
+  }
+  this.socket.prependListener(type, func);
+  return this;
+};
+
 Terminal.prototype.addListener =
 Terminal.prototype.on = function(type, func) {
   if (type === 'close') {


### PR DESCRIPTION
This seems to be a requirement for use with Node 6+ and doing a
`process.stdin.pipe(<pty.js instance>)` (possibly previous versions as
well, but I haven't checked)

Found while updating jedi4ever/ttyrec.js dependencies for use with newer
Node.js versions